### PR TITLE
Added Socket Environment Variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@
 
 # Ignore ENV variable file
 /config/initializers/_env.rb
-/config/database.yml

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   collation: utf8mb4_unicode_520_ci
   reconnect: false
   pool: 5
-  socket: /tmp/mysql.sock
+  socket: <%= ENV['SOCKET'] || '' %>
 
 development:
   <<: *default


### PR DESCRIPTION
We should finally stop having Mac vs Windows socket issues. Add one of the following to your config/initializers/_env.rb file. (First one is for Windows, the second one is for Mac). Note the implementation is identical to how we handled our different passwords. 
ENV['SOCKET'] = "/var/run/mysqld/mysqld.sock"
ENV['SOCKET'] = "/tmp/mysql.sock"
