### PR TITLE
Disabled rental button when no bikes and prevented user from resubmit…

### DIFF
--- a/app/controllers/rental_controller.rb
+++ b/app/controllers/rental_controller.rb
@@ -16,14 +16,21 @@ class RentalController < ApplicationController
     @numBikes = params[:numBikes].to_i # Gets number of bikes from parems, posted by rental page
     
     @stationNum = @stations.find{|s| s.name == @stationName}.id.to_i # Gets current station by name, to modify number of bikes
-    @bikeNums = Array(@numBikes)
+    @bikeIds = Array(@numBikes)
     i = 0
     while i < @numBikes do
       bike = Bike.find{|b| b.current_station_id == @stationNum} # Find bike at current station
-      @bikeNums[i] = bike.id # Get bike id for user
+      @bikeIds[i] = bike.id # Get bike id for user
       bike.update({'current_station_id': nil}) # Remove bike from station
+      bike.update({'checkoutTime': Time.now.inspect}) # Add checkout time
+      # b.update({'current_user_id': }) # Assign bike to user
       i += 1
     end
+    redirect_to(action: 'confirmation', stationName: @stationName, numBikes: @numBikes) # Prevents form resubmission
   end
-  
+
+  def confirmation 
+    @stationName = params[:stationName] # Gets current station from params, posted by rental page
+    @numBikes = params[:numBikes].to_i # Gets number of bikes from parems, posted by rental page
+  end
 end

--- a/app/views/rental/confirmation.html.erb
+++ b/app/views/rental/confirmation.html.erb
@@ -1,0 +1,3 @@
+<h1><%= @numBikes %> bike<% unless @numBikes == 1 %><%="s"%><% end %> 
+	at <%= @stationName %> successfully unlocked!</h1>
+		<h1>Enjoy your ride!<h1>

--- a/app/views/rental/index.html.erb
+++ b/app/views/rental/index.html.erb
@@ -38,7 +38,12 @@
 	stationNameField.addEventListener("change", updateMaxBikes); // Waits for station change
 
 	function updateMaxBikes() {
-		maxBikes = maxBikesHash[stationNameField.value];
+		stationName = stationNameField.value;
+		if (stationName == "") {
+			alert("No bikes availible, please check back later!");
+			document.getElementsByName("commit")[0].disabled = true; //Disable submit button
+		}
+		maxBikes = maxBikesHash[stationName];
         numBikesField.setAttribute("max", maxBikes); // Dynamically updates max value of number input field
         numBikesField.value = Math.min(numBikesField.value, maxBikes); // Decrements number of bikes if requested bikes exceeds number at new station
 	}

--- a/app/views/rental/unlock.html.erb
+++ b/app/views/rental/unlock.html.erb
@@ -1,4 +1,0 @@
-<h1><%= @numBikes %> bike<% unless @numBikes == 1 %><%="s"%><% end %> 
-	at <%= @stationName %> successfully unlocked!</h1>
-	<h2>Your bike is <%= @bikeNums %> </h2>
-		<h2>Enjoy your ride!<h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get 'bikes', to: "bikes#index"
   get 'rental', to: "rental#index"
   get 'unlock', to: "rental#unlock"
+  get 'confirmation', to: "rental#confirmation"
   get 'rental_success', to: "rental#success"
   get 'login', to: "login#index"
  # get 'signup', to: "login#new"


### PR DESCRIPTION
Disabled rental button when no bikes at any station and prevented user from resubmitting form by reloading. They can still break the system by using the back button, but that's a future issue to tackle if we have the time.