### PR TITLE
Updated bike model to have datetime objects, not time

### DIFF
--- a/db/migrate/20211104031247_bike_model_change_time_to_date_time.rb
+++ b/db/migrate/20211104031247_bike_model_change_time_to_date_time.rb
@@ -1,0 +1,6 @@
+class BikeModelChangeTimeToDateTime < ActiveRecord::Migration[6.1]
+  def change
+    change_column :bikes, :checkinTime, :datetime
+    change_column :bikes, :checkoutTime, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_032708) do
+ActiveRecord::Schema.define(version: 2021_11_04_031247) do
 
   create_table "bikes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.time "checkoutTime"
-    t.time "checkinTime"
+    t.datetime "checkoutTime"
+    t.datetime "checkinTime"
     t.integer "current_station_id"
     t.integer "current_user_id"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
Changed checkin and checkout variables to datetime objects rather than time objects. This allows us to more easily handle calculating the total rental time. (The old version set the date to January 1 2000). The key here was creating a new migration. 